### PR TITLE
Fix: deploy.yml typo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
           REDIS_URL: redis://localhost:6379/0
           ALLOWED_HOSTS: localhost,127.0.0.1
         run: |
-          cd appd
+          cd app
           python manage.py migrate
           python manage.py test
 


### PR DESCRIPTION
Fixes typo in deploy.yml - `appd` should be `app`.

This caused v0.2.0 deployment to fail.